### PR TITLE
Add Portuguese translations file to vendor/javascripts/locales

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datepicker/locales/bootstrap-datepicker.pt.js
+++ b/vendor/assets/javascripts/bootstrap-datepicker/locales/bootstrap-datepicker.pt.js
@@ -1,0 +1,14 @@
+/**
+ * Portuguese translation for bootstrap-datepicker
+ * Original code: Cauan Cabral <cauan@radig.com.br>
+ * Tiago Melo <tiago.blackcode@gmail.com>
+ */
+;(function($){
+	$.fn.datepicker.dates['pt'] = {
+		days: ["Domingo", "Segunda", "Terça", "Quarta", "Quinta", "Sexta", "Sábado", "Domingo"],
+		daysShort: ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb", "Dom"],
+		daysMin: ["Do", "Se", "Te", "Qu", "Qu", "Se", "Sa", "Do"],
+		months: ["Janeiro", "Fevereiro", "Março", "Abril", "Maio", "Junho", "Julho", "Agosto", "Setembro", "Outubro", "Novembro", "Dezembro"],
+		monthsShort: ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"]
+	};
+}(jQuery));


### PR DESCRIPTION
Although PT (Portuguese) translation is the same for the Brazilian translation, following Rails locales convention I think there should be a file specific for the Portuguese translation to allow for I18n applications to dynamically set the datepicker locale without any workarounds.

I kept the translation credits similar to the Brazilian ones.
