### PR TITLE
Rails 4 version fix (comparison of Gem::Version with String failed)

### DIFF
--- a/lib/bootstrap-datepicker-rails.rb
+++ b/lib/bootstrap-datepicker-rails.rb
@@ -3,7 +3,7 @@ require "bootstrap-datepicker-rails/version"
 
 module BootstrapDatepickerRails
   module Rails
-    if ::Rails.version < "3.1"
+    if ::Rails.version.to_s < "3.1"
       require "bootstrap-datepicker-rails/railtie"
     else
       require "bootstrap-datepicker-rails/engine"


### PR DESCRIPTION
Rails.version in Rails 4 will return Gem::Version.new not String. 

This will raise exception:

/Users/madmax/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/bundler/gems/bootstrap-datepicker-rails-4ea02449857e/lib/bootstrap-datepicker-rails.rb:6:in `<': comparison of Gem::Version with String failed (ArgumentError)

Here is commit in rails master https://github.com/rails/rails/commit/c07e1515f7c66f5599cbb3c7e9fe42e166bf3edc
