### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ You can fine tune the included files to suit your needs.
 
 ```javascript
 //= require bootstrap-datepicker/core
-//= require bootstrap-datepicker/locales/bootstrap-datepicker.es
-//= require bootstrap-datepicker/locales/bootstrap-datepicker.fr
+//= require bootstrap-datepicker/locales/bootstrap-datepicker.es.js
+//= require bootstrap-datepicker/locales/bootstrap-datepicker.fr.js
 ```
 
 ## Using bootstrap-datepicker-rails


### PR DESCRIPTION
Hello. This small pull-request contains fixed typos in `README`.
Without file extension, you're will get an error (like [#345](https://github.com/eternicode/bootstrap-datepicker/issues/345)):

```
bootstrap-datepicker/locales/bootstrap-datepicker.ru is 'text/x-script.ruby', not 'application/javascript'
```
