### PR TITLE
use a simpler html example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,7 @@ You can fine tune the included files to suit your needs.
 Just call datepicker() with any selector.
 
 ```html
-<input type="text" data-behaviour='datepicker' >
-
-<script type="text/javascript">
-  $(document).ready(function(){
-    $('[data-behaviour~=datepicker]').datepicker();
-  })
-</script>
+<input type="text" data-provide='datepicker' >
 ```
 
 Examples:


### PR DESCRIPTION
The datepicker already has the default `data-provide="datepicker"` attribute which it responds to:

https://github.com/Nerian/bootstrap-datepicker-rails/blob/master/vendor/assets/javascripts/bootstrap-datepicker/core.js#L1657
