### PR TITLE
Add the zIndexOffset option to configure the dialog "height"

### DIFF
--- a/vendor/assets/javascripts/bootstrap-datepicker/core.js
+++ b/vendor/assets/javascripts/bootstrap-datepicker/core.js
@@ -269,6 +269,7 @@
 				o.defaultViewDate = UTCToday();
 			}
 			o.showOnFocus = o.showOnFocus !== undefined ? o.showOnFocus : true;
+			o.zIndexOffset = o.zIndexOffset !== undefined ? o.zIndexOffset : 10;
 		},
 		_events: [],
 		_secondaryEvents: [],
@@ -602,7 +603,7 @@
 				var itemZIndex = $(this).css('z-index');
 				if (itemZIndex !== 'auto' && itemZIndex !== 0) parentsZindex.push(parseInt(itemZIndex));
 			});
-			var zIndex = Math.max.apply(Math, parentsZindex) + 10;
+			var zIndex = Math.max.apply(Math, parentsZindex) + this.o.zIndexOffset;
 			var offset = this.component ? this.component.parent().offset() : this.element.offset();
 			var height = this.component ? this.component.outerHeight(true) : this.element.outerHeight(false);
 			var width = this.component ? this.component.outerWidth(true) : this.element.outerWidth(false);


### PR DESCRIPTION
Previously, the height was computed to be 10 higher than the max height of all of the input's parents. In some cases where the date picker needs to move/scroll around with the page, it may collide with other fixed elements. In those cases, a configurable z-index is very helpful in order to keep the datepicker visible.